### PR TITLE
v3.1.2 - Fix Migrations

### DIFF
--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -1,4 +1,4 @@
-# VERSION 3.1.1
+# VERSION 3.1.2
 FROM ubuntu:18.04
 
 ENV APP_DIR=/app \

--- a/3/script/run.sh
+++ b/3/script/run.sh
@@ -11,6 +11,6 @@ bundle exec rails webpacker:compile
 rails assets:precompile
 
 # Check for database and migrate or setup the database
-rake db:exists && rake db:migrate || rake db:setup
+rake db:exists && rake db:migrate || rake db:setup && rake db:migrate
 
 nginx

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a base docker image for running rails web applications using nginx and p
 # Tags
 * [1, 1.0.0](1/Dockerfile) - Built off the official Ubuntu 18.04 image with ruby 2.5.1.
 * [2, 2.0.0](2/Dockerfile) - Built off the official Ubuntu 18.04 image with ruby 2.7.
-* [3, 3.1.1](3/Dockerfile) - Built off the official Ubuntu 18.04 image with ruby 2.7 and node installed.
+* [3, 3.1.2](3/Dockerfile) - Built off the official Ubuntu 18.04 image with ruby 2.7 and node installed.
 
 ## Usage
 This image is best used with docker-compose. The `docker-compose.yml` in the rails app should contain the following at minimum:


### PR DESCRIPTION
This PR updates the run.sh script to fix an issue where migrations
weren't run if the database didn't exist on deployment.

It also bumps the version.